### PR TITLE
# Move minimum Ruby requirement to 2.1, test against 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
 
 gemfile:
   - gemfiles/Gemfile.rails32

--- a/ndr_support.gemspec
+++ b/ndr_support.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.1.0'
 
   # Avoid std-lib minitest (which has different namespace)
   spec.add_development_dependency 'minitest', '>= 5.0.0'


### PR DESCRIPTION
We should drop support for old rubies, now we no longer require it.