### PR TITLE
Added Integer#working_days_since

### DIFF
--- a/lib/ndr_support/date_and_time_extensions.rb
+++ b/lib/ndr_support/date_and_time_extensions.rb
@@ -1,8 +1,6 @@
 require 'yaml'
 require 'date'
-
-require 'ndr_support/concerns/working_days'
-[Time, Date, DateTime].each { |klass| klass.send(:include, WorkingDays) }
+require 'ndr_support/working_days'
 
 class Date
   # to_iso output must be SQL safe for security reasons

--- a/lib/ndr_support/integer/working_days.rb
+++ b/lib/ndr_support/integer/working_days.rb
@@ -1,0 +1,11 @@
+# Mixin for working_days
+class Integer
+  # Returns a date of the number of working days since a given date
+  def working_days_since(date)
+    times do
+      date = date.next
+      date = date.next while date.public_holiday? || !date.weekday?
+    end
+    date
+  end
+end

--- a/lib/ndr_support/working_days.rb
+++ b/lib/ndr_support/working_days.rb
@@ -1,0 +1,5 @@
+require 'date'
+require 'ndr_support/concerns/working_days'
+require 'ndr_support/integer/working_days'
+
+[Time, Date, DateTime].each { |klass| klass.send(:include, WorkingDays) }

--- a/test/integer/working_days_test.rb
+++ b/test/integer/working_days_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+# This tests our Integer working days extension
+class Integer::WorkingDaysTest < Minitest::Test
+  test 'Integer should be extended with #working_days_since' do
+    assert 1.respond_to?(:working_days_since)
+  end
+
+  test 'Integer#working_days_since should behave correctly' do
+    assert_equal Date.new(2019, 12, 23), 1.working_days_since(Date.new(2019, 12, 20))
+    assert_equal Date.new(2019, 12, 27), 3.working_days_since(Date.new(2019, 12, 20))
+    assert_equal Date.new(2019, 12, 30), 4.working_days_since(Date.new(2019, 12, 20))
+  end
+end


### PR DESCRIPTION
Expanding on the existing working_days date and time extensions, this extends Integer with a working_days_since method. For simplicity and expediency, I haven't looked to create a WorkingDaysDuration class or similar, but it would be nice to have `3.working_days.since()` and `3.working_days.ago()` at some point.