### PR TITLE
ndr_dev_support bump to v5.4

### DIFF
--- a/ndr_support.gemspec
+++ b/ndr_support.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '>= 5.0.0'
   spec.add_development_dependency 'mocha', '~> 1.1'
 
-  spec.add_development_dependency 'ndr_dev_support', '~> 3.1', '>= 3.1.3'
+  spec.add_development_dependency 'ndr_dev_support', '~> 5.4', '>= 5.4.5'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'listen', '< 3.1' # Bundle 1.12 should be (but isn't) resolving Ruby 2.1 issue
   spec.add_development_dependency 'guard-rubocop'


### PR DESCRIPTION
The previous version of ndr_dev_support does not work with the latest `.rubocop.yml`, hence the need for this bump.