### PR TITLE
Adds 2021 holidays and tests against GOV.UK. Relates to #8

### DIFF
--- a/lib/ndr_support/concerns/working_days.rb
+++ b/lib/ndr_support/concerns/working_days.rb
@@ -88,6 +88,15 @@ module WorkingDays
     '2020-08-31', # Monday    - Summer bank holiday
     '2020-12-25', # Friday    - Christmas Day
     '2020-12-28', # Monday    - Boxing Day (substitute day)
+    # 2021
+    '2021-01-01', # Friday - New Year’s Day
+    '2021-04-02', # Friday - Good Friday
+    '2021-04-05', # Monday - Easter Monday
+    '2021-05-03', # Monday - Early May bank holiday
+    '2021-05-31', # Monday - Spring bank holiday
+    '2021-08-30', # Monday - Summer bank holiday
+    '2021-12-27', # Monday - Christmas Day
+    '2021-12-28', # Tuesday - Boxing Day
   ].map { |str| Date.parse(str) }
 
   def self.check_lookup

--- a/test/concerns/working_days_test.rb
+++ b/test/concerns/working_days_test.rb
@@ -119,4 +119,22 @@ class WorkingDaysTest < Minitest::Test
     assert_equal 253, @normal_time.working_days_until(@normal_time + 1.year)
     assert_equal 253, @normal_date_time.working_days_until(@normal_date_time + 1.year)
   end
+
+  test 'against GOV.UK holidays' do
+    require 'net/http'
+    require 'json'
+
+    url = 'https://www.gov.uk/bank-holidays/england-and-wales.json'
+    response = Net::HTTP.get(URI(url))
+
+    events = JSON.parse(response)['events']
+    events.each do |event|
+      event_date = event['date']
+      parsed_date = Date.parse(event_date)
+
+      assert parsed_date.public_holiday?, "#{event_date} should be a public holiday"
+      # next if parsed_date.public_holiday?
+      # puts "'#{event_date}', # #{parsed_date.strftime('%A')} - #{event['title']}"
+    end
+  end
 end


### PR DESCRIPTION
As discussed, this adds a test to test know bank holidays against the GOV.UK list (ignoring bunting) and adds the subsequently missing 2021 holidays